### PR TITLE
Added ga-beacon SVG Badge

### DIFF
--- a/static/badge.svg
+++ b/static/badge.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="81" height="18">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-opacity=".3"/>
+    <stop offset="1" stop-opacity=".5"/>
+  </linearGradient>
+  <rect rx="4" width="81" height="18" fill="#555"/>
+  <rect rx="4" x="56" width="25" height="18" fill="#1288ca"/>
+  <path fill="#1288ca" d="M56 0h4v18h-4z"/>
+  <rect rx="4" width="81" height="18" fill="url(#a)"/>
+  <g fill="#fff" text-anchor="middle"
+     font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="28" y="13" fill="#010101" fill-opacity=".3">analytics</text>
+    <text x="28" y="12">analytics</text>
+    <text x="68" y="13" fill="#010101" fill-opacity=".3">GA</text>
+    <text x="68" y="12">GA</text>
+  </g>
+</svg>


### PR DESCRIPTION
Hi Ilya, I have created an SVG badge for ga-beacon similar to many others: NPM version, build status, dev dependencies.

It took a little time to get it right changing pixels by hand in the editor. But text should be  proportional now to the width of the badge:

![screen shot 2014-04-04 at 5 20 31 pm](https://cloud.githubusercontent.com/assets/544954/2620534/f17a324e-bc3f-11e3-8820-f8f82dc07718.png)

Best of all this new badge looks good at any resolution, whereas `badge.gif` looks awful at normal resolution on retina displays.
![screen shot 2014-04-04 at 5 21 36 pm](https://cloud.githubusercontent.com/assets/544954/2620539/0d337d4c-bc40-11e3-86f9-346dbd413cbf.png)

I am not familiar with Google Go, so I couldn't update it to serve SVG instead of GIF. There are two choices, either one is acceptable:
1. Replace GIF with SVG completely.
2. Server SVG if you pass `?svg` flag:

``` go
var (
    pixel        = mustReadFile("static/pixel.gif")
    badge        = mustReadFile("static/badge.gif")
    badgeSvg        = mustReadFile("static/badge.svg")
    pageTemplate = template.Must(template.New("page").ParseFiles("ga-beacon/page.html"))
)
```

and

``` go
query, _ := url.ParseQuery(r.URL.RawQuery)
    if _, ok := query["pixel"]; ok {
        w.Write(pixel)
    } else if _, ok := query["svg"]; ok {
        w.Write(badgeSvg)
    } else {
        w.Write(badge)
    }
```
