### PR TITLE
Added query parameter `?gif` to return gif image of badge

### DIFF
--- a/ga-beacon/ga-beacon.go
+++ b/ga-beacon/ga-beacon.go
@@ -20,6 +20,7 @@ const beaconURL = "http://www.google-analytics.com/collect"
 var (
 	pixel        = mustReadFile("static/pixel.gif")
 	badge        = mustReadFile("static/badge.svg")
+	badgeGif     = mustReadFile("static/badge.gif")
 	pageTemplate = template.Must(template.New("page").ParseFiles("ga-beacon/page.html"))
 )
 
@@ -125,6 +126,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if _, ok := query["pixel"]; ok {
 		w.Header().Set("Content-Type", "image/gif")
 		w.Write(pixel)
+	} else if _, ok := query["gif"]; ok {
+	        w.Header().Set("Content-Type", "image/gif")
+                w.Write(badgeGif)
 	} else {
 		w.Header().Set("Content-Type", "image/svg+xml")
 		w.Write(badge)


### PR DESCRIPTION
Option to return a gif image of the badge for browsers/services that don't allow svg. See comment on  https://github.com/igrigorik/ga-beacon/pull/8#issuecomment-57148254
