### PR TITLE
Add Expires header

### DIFF
--- a/ga-beacon/ga-beacon.go
+++ b/ga-beacon/ga-beacon.go
@@ -144,9 +144,8 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(cid) != 0 {
-		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Cache-Control", "private, no-store")
 		w.Header().Set("CID", cid)
-		w.Header().Set("Expires", "Wed, 07 Jun 2017 19:47:34 GMT")
 
 		logHit(c, params, query, r.Header.Get("User-Agent"), r.RemoteAddr, cid)
 		// delayHit.Call(c, params, r.Header.Get("User-Agent"), cid)

--- a/ga-beacon/ga-beacon.go
+++ b/ga-beacon/ga-beacon.go
@@ -146,6 +146,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if len(cid) != 0 {
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("CID", cid)
+		w.Header().Set("Expires", "Wed, 07 Jun 2017 19:47:34 GMT")
 
 		logHit(c, params, query, r.Header.Get("User-Agent"), r.RemoteAddr, cid)
 		// delayHit.Call(c, params, r.Header.Get("User-Agent"), cid)


### PR DESCRIPTION
According to https://github.com/github/markup/issues/224#issuecomment-37663375, `Cache-Control` is not enought and also require `Etag`, `Expires` or `Last-Modified` header.

A dynamic `Etag` value should have been OK as well (https://en.wikipedia.org/wiki/HTTP_ETag#Typical_usage)