### PR TITLE
Change http response headers (cache-control changed, expires added)

### DIFF
--- a/ga-beacon.go
+++ b/ga-beacon.go
@@ -146,7 +146,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	if len(cid) != 0 {
 		var cacheUntil = time.Now().Format(http.TimeFormat)
-		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate, private")
 		w.Header().Set("Expires", cacheUntil)
 		w.Header().Set("CID", cid)
 

--- a/ga-beacon.go
+++ b/ga-beacon.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"appengine"
 	"appengine/delay"
@@ -105,11 +106,11 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	// activate referrer path if ?useReferer is used and if referer exists
 	if _, ok := query["useReferer"]; ok {
 		if len(refOrg) != 0 {
-			referer := strings.Replace(strings.Replace(refOrg, "http://", "", 1), "https://", "", 1);
+			referer := strings.Replace(strings.Replace(refOrg, "http://", "", 1), "https://", "", 1)
 			if len(referer) != 0 {
 				// if the useReferer is present and the referer information exists
 				//  the path is ignored and the beacon referer information is used instead.
-				params = strings.SplitN(strings.Trim(r.URL.Path, "/") + "/" + referer, "/", 2)
+				params = strings.SplitN(strings.Trim(r.URL.Path, "/")+"/"+referer, "/", 2)
 			}
 		}
 	}
@@ -144,7 +145,9 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(cid) != 0 {
-		w.Header().Set("Cache-Control", "private, no-store")
+		var cacheUntil = time.Now().Format(http.TimeFormat)
+		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+		w.Header().Set("Expires", cacheUntil)
 		w.Header().Set("CID", cid)
 
 		logHit(c, params, query, r.Header.Get("User-Agent"), r.RemoteAddr, cid)


### PR DESCRIPTION
I tried using ga-beacon on github today for the first time (2018-03-17). It worked once, while I was editing the README.md, but then updates to analytics stopped. I looked into the source of the landing page of my repo returned by github (the rendering of README.md) and the beacon image was cached. Googling the problem led to rather old tickets in github's own issue tracker. The suggestion by them was to set `cache-control` and `expires`. This looks work for me, I've deployed the patched version to https://ga-beacon-nocache.appspot.com if you want to try it out.

I'm setting the expired http header to `now`, but i'm not exactly sure if that's ok. Maybe it will make more sense to set it to like a few minutes in the future.