### PR TITLE
GAE requires Go 1.12+ from June 30 2020

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,4 @@
-runtime: go
-api_version: go1
+runtime: go113
 
 default_expiration: "1d"
 


### PR DESCRIPTION
* runtime should be 112 o 113 because old versions (1.9) were deprecated by GAE and will be disconnected
* api_version was deprecated from YAML syntax.

For more details see:  https://cloud.google.com/appengine/docs/standard/go/go-differences?_ga=2.179511661.-814713571.1592915957#app-yaml