### PR TITLE
Change handler for Go files

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -8,4 +8,4 @@ handlers:
   upload: static/favicon\.ico
 
 - url: /.*
-  script: _go_app
+  script: auto


### PR DESCRIPTION
New deploys in GAE requires "auto" instead "_go_app" for script handlers variable.