### PR TITLE
Update beacon URL to use HTTPS

### DIFF
--- a/ga-beacon.go
+++ b/ga-beacon.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/appengine/delay"
 )
 
-const beaconURL = "http://www.google-analytics.com/collect"
+const beaconURL = "https://www.google-analytics.com/collect"
 
 var (
 	pixel        = mustReadFile("static/pixel.gif")


### PR DESCRIPTION
See https://developers.google.com/analytics/devguides/collection/protocol/v1/reference